### PR TITLE
Updates to other packages and a couple of changes to rendermime

### DIFF
--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -24,7 +24,7 @@ import {
 } from '@jupyterlab/console';
 
 import {
-  RenderMime
+  RenderMime, defaultRendererFactories
 } from '@jupyterlab/rendermime';
 
 import '@jupyterlab/theming/style/index.css';
@@ -69,8 +69,9 @@ function startApp(path: string, manager: ServiceManager.IManager) {
     commands.processKeydownEvent(event);
   });
 
-  let initialFactories = RenderMime.getDefaultFactories();
-  let rendermime = new RenderMime({ initialFactories });
+  let rendermime = new RenderMime({
+    initialFactories: defaultRendererFactories
+  });
 
   let editorFactory = editorServices.factoryService.newInlineEditor.bind(
     editorServices.factoryService);

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -37,7 +37,7 @@ import {
 } from '@jupyterlab/docregistry';
 
 import {
-  RenderMime
+  RenderMime, defaultRendererFactories
 } from '@jupyterlab/rendermime';
 
 
@@ -94,8 +94,9 @@ function createApp(manager: ServiceManager.IManager): void {
     commands.processKeydownEvent(event);
   }, useCapture);
 
-  let initialFactories = RenderMime.getDefaultFactories();
-  let rendermime = new RenderMime({ initialFactories });
+  let rendermime = new RenderMime({
+    initialFactories: defaultRendererFactories
+  });
 
   let opener = {
     open: (widget: Widget) => {

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@jupyterlab/docregistry';
 
 import {
-  IRenderMime, RenderMime
+  IRenderMime, RenderMime, defaultRendererFactories
 } from '@jupyterlab/rendermime';
 
 import {
@@ -66,7 +66,7 @@ class JupyterLab extends Application<ApplicationShell> {
         linker.connectNode(node, 'file-operations:open', { path });
       }
     };
-    let initialFactories = RenderMime.getDefaultFactories();
+    let initialFactories = defaultRendererFactories;
     this.rendermime = new RenderMime({ initialFactories, linkHandler });
 
     let registry = this.docRegistry = new DocumentRegistry();

--- a/packages/application/src/mimerenderers.ts
+++ b/packages/application/src/mimerenderers.ts
@@ -35,9 +35,9 @@ function createRendermimePlugins(extensions: IRenderMime.IExtensionModule[]): Ju
       data = mod as any;
     }
     if (!Array.isArray(data)) {
-      data = [data];
+      data = [data] as ReadonlyArray<IRenderMime.IExtension>;
     }
-    data.forEach(item => {
+    (data as ReadonlyArray<IRenderMime.IExtension>).forEach(item => {
       let plugin = createRendermimePlugin(item);
       plugins.push(plugin);
     });
@@ -59,10 +59,10 @@ function createRendermimePlugin(item: IRenderMime.IExtension): JupyterLabPlugin<
       // Add the mime renderer.
       if (item.rank !== undefined) {
         app.rendermime.addFactory(
-          item.rendererFactory, item.mimeType, item.rank
+          item.rendererFactory, item.rank
         );
       } else {
-        app.rendermime.addFactory(item.rendererFactory, item.mimeType);
+        app.rendermime.addFactory(item.rendererFactory);
       }
 
       // Handle the widget factory.

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -836,7 +836,7 @@ class MarkdownCell extends Cell {
     if (text !== this._prevText) {
       let mimeModel = new MimeModel({ data: { 'text/markdown': text }});
       if (!this._renderer) {
-        this._renderer = this._rendermime.createRenderer(mimeModel);
+        this._renderer = this._rendermime.createRenderer('text/markdown');
         this._renderer.addClass(MARKDOWN_OUTPUT_CLASS);
       }
       this._prevText = text;

--- a/packages/docregistry/src/default.ts
+++ b/packages/docregistry/src/default.ts
@@ -505,7 +505,7 @@ class MimeRenderer extends Widget implements DocumentRegistry.IReadyWidget {
     }
     let mimeModel = new MimeModel({ data });
     if (!this._renderer) {
-      this._renderer = this.rendermime.createRenderer(mimeModel);
+      this._renderer = this.rendermime.createRenderer(this._mimeType);
       (this.layout as PanelLayout).addWidget(this._renderer);
     }
     return this._renderer.renderModel(mimeModel);

--- a/packages/inspector/src/handler.ts
+++ b/packages/inspector/src/handler.ts
@@ -185,11 +185,16 @@ class InspectionHandler implements IDisposable, IInspector.IInspectable {
       }
 
       const data = value.data;
-      const model = new MimeModel({ data, trusted: true });
 
-      let widget = this._rendermime.createRenderer(model);
-      widget.renderModel(model);
-      update.content = widget;
+      let mimeType = this._rendermime.preferredMimeType(data, true);
+      if (mimeType) {
+        let widget = this._rendermime.createRenderer(mimeType);
+        const model = new MimeModel({ data });
+        widget.renderModel(model);
+        update.content = widget;
+      } else {
+        update.content = null;
+      }
       this._inspected.emit(update);
     });
   }

--- a/packages/outputarea/src/widget.ts
+++ b/packages/outputarea/src/widget.ts
@@ -414,8 +414,11 @@ class OutputArea extends Widget {
     prompt.addClass(OUTPUT_AREA_PROMPT_CLASS);
     panel.addWidget(prompt);
 
-    let output = this.rendermime.createRenderer(model);
-    if (output) {
+    let mimeType = this.rendermime.preferredMimeType(
+      model.data, !model.trusted
+    );
+    if (mimeType) {
+      let output = this.rendermime.createRenderer(mimeType);
       output.renderModel(model);
       output.addClass(OUTPUT_AREA_OUTPUT_CLASS);
       panel.addWidget(output);

--- a/packages/rendermime/src/renderhelpers.ts
+++ b/packages/rendermime/src/renderhelpers.ts
@@ -53,9 +53,11 @@ namespace RenderHelpers {
       node, source, trusted, sanitizer, resolver, linkHandler, shouldTypeset
     } = options;
 
-    // Clear the content if there is no source.
+    // Clear any existing content.
+    node.textContent = '';
+
+    // Bail if there is no source.
     if (!source) {
-      node.textContent = '';
       return Promise.resolve(undefined);
     }
 
@@ -64,8 +66,15 @@ namespace RenderHelpers {
       source = sanitizer.sanitize(source);
     }
 
-    // Set the inner HTML to the source.
-    node.innerHTML = source;
+    // Add the html to the node.
+    try {
+      let range = document.createRange();
+      node.appendChild(range.createContextualFragment(source));
+    } catch (error) {
+      console.warn('Environment does not support Range ' +
+                   'createContextualFragment, falling back on innerHTML');
+      node.innerHTML = source;
+    }
 
     // Patch the urls if a resolver is available.
     let promise: Promise<void>;

--- a/packages/rendermime/src/rendermime.ts
+++ b/packages/rendermime/src/rendermime.ts
@@ -215,7 +215,7 @@ namespace RenderMime {
     /**
      * Intial factories to add to the rendermime instance.
      */
-    initialFactories?: IRenderMime.IRendererFactory[];
+    initialFactories?: ReadonlyArray<IRenderMime.IRendererFactory>;
 
     /**
      * The sanitizer used to sanitize untrusted html inputs.

--- a/packages/rendermime/src/widgets.ts
+++ b/packages/rendermime/src/widgets.ts
@@ -39,7 +39,7 @@ abstract class RenderedCommon extends Widget implements IRenderMime.IRenderer {
     this.sanitizer = options.sanitizer;
     this.resolver = options.resolver;
     this.linkHandler = options.linkHandler;
-    this.node.dataset['mime-type'] = this.mimeType;
+    this.node.dataset['mimeType'] = this.mimeType;
   }
 
   /**

--- a/packages/tooltip/src/widget.ts
+++ b/packages/tooltip/src/widget.ts
@@ -77,11 +77,13 @@ class Tooltip extends Widget {
     let model = new MimeModel({
       data: options.bundle
     });
-    this._content = this._rendermime.createRenderer(model);
-    if (this._content) {
-      this._content.renderModel(model);
-      layout.addWidget(this._content);
+    let mimeType = this._rendermime.preferredMimeType(options.bundle, false);
+    if (!mimeType) {
+      return;
     }
+    this._content = this._rendermime.createRenderer(mimeType);
+    this._content.renderModel(model);
+    layout.addWidget(this._content);
   }
 
   /**

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -107,7 +107,7 @@ class RenderedVega extends Widget implements IRenderMime.IRenderer {
 export
 const rendererFactory: IRenderMime.IRendererFactory = {
   safe: true,
-  mimeTypes: ['text/html'],
+  mimeTypes: [VEGA_MIME_TYPE, VEGALITE_MIME_TYPE],
   createRenderer: options => new RenderedVega(options)
 };
 

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -102,39 +102,14 @@ class RenderedVega extends Widget implements IRenderMime.IRenderer {
 
 
 /**
- * A mime renderer factory for Vega/Vega-Lite data.
+ * A mime renderer factory for vega data.
  */
 export
-class VegaRendererFactory implements IRenderMime.IRendererFactory {
-  /**
-   * The mimeTypes this renderer accepts.
-   */
-  mimeTypes = [VEGA_MIME_TYPE, VEGALITE_MIME_TYPE];
-
-  /**
-   * Whether the renderer can create a renderer given the render options.
-   */
-  canCreateRenderer(options: IRenderMime.IRendererOptions): boolean {
-    return this.mimeTypes.indexOf(options.mimeType) !== -1;
-  }
-
-  /**
-   * Render the transformed mime bundle.
-   */
-  createRenderer(options: IRenderMime.IRendererOptions): IRenderMime.IRenderer {
-    return new RenderedVega(options);
-  }
-
-  /**
-   * Whether the renderer will sanitize the data given the render options.
-   */
-  wouldSanitize(options: IRenderMime.IRendererOptions): boolean {
-    return false;
-  }
-}
-
-
-const rendererFactory = new VegaRendererFactory();
+const rendererFactory: IRenderMime.IRendererFactory = {
+  safe: true,
+  mimeTypes: ['text/html'],
+  createRenderer: options => new RenderedVega(options)
+};
 
 const extensions: IRenderMime.IExtension | IRenderMime.IExtension[] = [
   // Vega

--- a/test/src/rendermime/factories.spec.ts
+++ b/test/src/rendermime/factories.spec.ts
@@ -16,28 +16,13 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  LatexRendererFactory, PDFRendererFactory, JavaScriptRendererFactory,
-  SVGRendererFactory, MarkdownRendererFactory, TextRendererFactory, HTMLRendererFactory, ImageRendererFactory
+  latexRendererFactory, pdfRendererFactory, javaScriptRendererFactory,
+  svgRendererFactory, markdownRendererFactory, textRendererFactory, htmlRendererFactory, imageRendererFactory
 } from '@jupyterlab/rendermime';
 
 import {
   MimeModel, IRenderMime
 } from '@jupyterlab/rendermime';
-
-
-function runCanCreateRenderer(renderer: IRenderMime.IRendererFactory, trusted: boolean): boolean {
-  let canCreateRenderer = true;
-
-  for (let mimeType of renderer.mimeTypes) {
-    let options = { mimeType, sanitizer, trusted };
-    if (!renderer.canCreateRenderer(options)) {
-      canCreateRenderer = false;
-    }
-  }
-  let options = { trusted, mimeType: 'fizz/buzz', sanitizer };
-  expect(renderer.canCreateRenderer(options)).to.be(false);
-  return canCreateRenderer;
-}
 
 
 function createModel(mimeType: string, source: JSONValue, trusted = false): IRenderMime.IMimeModel {
@@ -47,29 +32,31 @@ function createModel(mimeType: string, source: JSONValue, trusted = false): IRen
 }
 
 const sanitizer = defaultSanitizer;
+const defaultOptions: any = {
+  sanitizer,
+  linkHandler: null,
+  resolver: null
+};
 
 
 describe('rendermime/factories', () => {
 
-  describe('TextRendererFactory', () => {
+  describe('textRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should have text related mimeTypes', () => {
         let mimeTypes = ['text/plain', 'application/vnd.jupyter.stdout',
                'application/vnd.jupyter.stderr'];
-        let f = new TextRendererFactory();
-        expect(f.mimeTypes).to.eql(mimeTypes);
+        expect(textRendererFactory.mimeTypes).to.eql(mimeTypes);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted and untrusted text data', () => {
-        let f = new TextRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(true);
+      it('should be safe', () => {
+        expect(textRendererFactory.safe).to.be(true);
       });
 
     });
@@ -77,35 +64,32 @@ describe('rendermime/factories', () => {
     describe('#createRenderer()', () => {
 
       it('should output the correct HTML', () => {
-        let f = new TextRendererFactory();
+        let f = textRendererFactory;
         let mimeType = 'text/plain';
         let model = createModel(mimeType, 'x = 2 ** a');
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.innerHTML).to.be('<pre>x = 2 ** a</pre>');
         });
       });
 
       it('should output the correct HTML with ansi colors', () => {
-        let f = new TextRendererFactory();
+        let f = textRendererFactory;
         let source = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
         let mimeType = 'application/vnd.jupyter.console-text';
         let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.innerHTML).to.be('<pre>There is no text but <span class="ansi-bright-green-fg ansi-red-bg">text</span>.\nWoo.</pre>');
         });
       });
 
       it('should escape inline html', () => {
-        let f = new TextRendererFactory();
+        let f = textRendererFactory;
         let source = 'There is no text <script>window.x=1</script> but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
         let mimeType = 'application/vnd.jupyter.console-text';
         let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.innerHTML).to.be('<pre>There is no text &lt;script&gt;window.x=1&lt;/script&gt; but <span class="ansi-bright-green-fg ansi-red-bg">text</span>.\nWoo.</pre>');
         });
@@ -115,23 +99,20 @@ describe('rendermime/factories', () => {
 
   });
 
-  describe('LatexRendererFactory', () => {
+  describe('latexRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should have the text/latex mimeType', () => {
-        let t = new LatexRendererFactory();
-        expect(t.mimeTypes).to.eql(['text/latex']);
+        expect(latexRendererFactory.mimeTypes).to.eql(['text/latex']);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted and untrusted latex data', () => {
-        let f = new LatexRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(true);
+      it('should be safe', () => {
+        expect(latexRendererFactory.safe).to.be(true);
       });
 
     });
@@ -140,11 +121,10 @@ describe('rendermime/factories', () => {
 
       it('should set the textContent of the widget', () => {
         let source = '\sum\limits_{i=0}^{\infty} \frac{1}{n^2}';
-        let f = new LatexRendererFactory();
+        let f = latexRendererFactory;
         let mimeType = 'text/latex';
         let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.textContent).to.be(source);
         });
@@ -154,23 +134,20 @@ describe('rendermime/factories', () => {
 
   });
 
-  describe('PDFRendererFactory', () => {
+  describe('pdfRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should have the application/pdf mimeType', () => {
-        let f = new PDFRendererFactory();
-        expect(f.mimeTypes).to.eql(['application/pdf']);
+        expect(pdfRendererFactory.mimeTypes).to.eql(['application/pdf']);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted pdf data', () => {
-        let f = new PDFRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(false);
+      it('should be unsafe', () => {
+        expect(pdfRendererFactory.safe).to.be(false);
       });
 
     });
@@ -179,11 +156,10 @@ describe('rendermime/factories', () => {
 
       it('should render the correct HTML', () => {
         let source = 'test';
-        let f = new PDFRendererFactory();
+        let f = pdfRendererFactory;
         let mimeType = 'application/pdf';
-        let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let model = createModel(mimeType, source, true);
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           let node = w.node.firstChild as HTMLAnchorElement;
           expect(node.localName).to.be('a');
@@ -196,24 +172,21 @@ describe('rendermime/factories', () => {
 
   });
 
-  describe('JavaScriptRendererFactory', () => {
+  describe('javaScriptRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should have the text/javascript mimeType', () => {
         let mimeTypes = ['text/javascript', 'application/javascript'];
-        let f = new JavaScriptRendererFactory();
-        expect(f.mimeTypes).to.eql(mimeTypes);
+        expect(javaScriptRendererFactory.mimeTypes).to.eql(mimeTypes);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted JavaScript data', () => {
-        let f = new JavaScriptRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(false);
+      it('should not be safe', () => {
+        expect(javaScriptRendererFactory.safe).to.be(false);
       });
 
     });
@@ -221,12 +194,11 @@ describe('rendermime/factories', () => {
     describe('#createRenderer()', () => {
 
       it('should create a script tag', () => {
-        let f = new JavaScriptRendererFactory();
+        let f = javaScriptRendererFactory;
         let source = 'window.x = 1';
         let mimeType = 'text/javascript';
-        let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let model = createModel(mimeType, source, true);
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           let el = w.node.firstChild as HTMLElement;
           expect(el.localName).to.be('script');
@@ -246,23 +218,20 @@ describe('rendermime/factories', () => {
 
   });
 
-  describe('SVGRendererFactory', () => {
+  describe('svgRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should have the image/svg+xml mimeType', () => {
-        let f = new SVGRendererFactory();
-        expect(f.mimeTypes).to.eql(['image/svg+xml']);
+        expect(svgRendererFactory.mimeTypes).to.eql(['image/svg+xml']);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted SVG data', () => {
-        let f = new SVGRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(false);
+      it('should not be safe', () => {
+        expect(svgRendererFactory.safe).to.be(false);
       });
 
     });
@@ -271,11 +240,10 @@ describe('rendermime/factories', () => {
 
       it('should create an svg tag', () => {
         const source = '<svg></svg>';
-        let f = new SVGRendererFactory();
+        let f = svgRendererFactory;
         let mimeType = 'image/svg+xml';
-        let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let model = createModel(mimeType, source, true);
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           let svgEl = w.node.getElementsByTagName('svg')[0];
           expect(svgEl).to.be.ok();
@@ -286,23 +254,20 @@ describe('rendermime/factories', () => {
 
   });
 
-  describe('MarkdownRendererFactory', () => {
+  describe('markdownRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should have the text/markdown mimeType', function() {
-        let f = new MarkdownRendererFactory();
-        expect(f.mimeTypes).to.eql(['text/markdown']);
+        expect(markdownRendererFactory.mimeTypes).to.eql(['text/markdown']);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted and untrusted markdown data', () => {
-        let f = new MarkdownRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(true);
+      it('should be safe', () => {
+        expect(markdownRendererFactory.safe).to.be(true);
       });
 
     });
@@ -310,12 +275,11 @@ describe('rendermime/factories', () => {
     describe('#createRenderer()', () => {
 
       it('should set the inner html', () => {
-        let f = new MarkdownRendererFactory();
+        let f = markdownRendererFactory;
         let source = '<p>hello</p>';
         let mimeType = 'text/markdown';
         let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.innerHTML).to.be(source);
         });
@@ -323,11 +287,10 @@ describe('rendermime/factories', () => {
 
       it('should add header anchors', () => {
         let source = require('../../../examples/filebrowser/sample.md') as string;
-        let f = new MarkdownRendererFactory();
+        let f = markdownRendererFactory;
         let mimeType = 'text/markdown';
         let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           Widget.attach(w, document.body);
           let node = document.getElementById('Title-third-level');
@@ -342,12 +305,11 @@ describe('rendermime/factories', () => {
       });
 
       it('should sanitize the html', () => {
-        let f = new MarkdownRendererFactory();
+        let f = markdownRendererFactory;
         let source = '<p>hello</p><script>alert("foo")</script>';
         let mimeType = 'text/markdown';
         let model = createModel(mimeType, source);
-        let trusted = false;
-        let w = f.createRenderer({ mimeType, trusted, sanitizer });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.innerHTML).to.not.contain('script');
         });
@@ -357,23 +319,20 @@ describe('rendermime/factories', () => {
 
   });
 
-  describe('HTMLRendererFactory', () => {
+  describe('htmlRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should have the text/html mimeType', () => {
-        let f = new HTMLRendererFactory();
-        expect(f.mimeTypes).to.eql(['text/html']);
+        expect(htmlRendererFactory.mimeTypes).to.eql(['text/html']);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted and untrusted html data', () => {
-        let f = new HTMLRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(true);
+      it('should be safe', () => {
+        expect(htmlRendererFactory.safe).to.be(true);
       });
 
     });
@@ -381,12 +340,11 @@ describe('rendermime/factories', () => {
     describe('#createRenderer()', () => {
 
       it('should set the inner HTML', () => {
-        let f = new HTMLRendererFactory();
+        let f = htmlRendererFactory;
         const source = '<h1>This is great</h1>';
         let mimeType = 'text/html';
         let model = createModel(mimeType, source);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.innerHTML).to.be('<h1>This is great</h1>');
         });
@@ -394,11 +352,10 @@ describe('rendermime/factories', () => {
 
       it('should execute a script tag when attached', () => {
         const source = '<script>window.y=3;</script>';
-        let f = new HTMLRendererFactory();
+        let f = htmlRendererFactory;
         let mimeType = 'text/html';
         let model = createModel(mimeType, source, true);
-        let trusted = true;
-        let w = f.createRenderer({ mimeType, sanitizer, trusted });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect((window as any).y).to.be(void 0);
           Widget.attach(w, document.body);
@@ -409,11 +366,10 @@ describe('rendermime/factories', () => {
 
       it('should sanitize when untrusted', () => {
         const source = '<pre><script>window.y=3;</script></pre>';
-        let f = new HTMLRendererFactory();
+        let f = htmlRendererFactory;
         let mimeType = 'text/html';
         let model = createModel(mimeType, source);
-        let trusted = false;
-        let w = f.createRenderer({ mimeType, trusted, sanitizer });
+        let w = f.createRenderer({ mimeType, ...defaultOptions });
         return w.renderModel(model).then(() => {
           expect(w.node.innerHTML).to.be('<pre></pre>');
         });
@@ -423,10 +379,9 @@ describe('rendermime/factories', () => {
 
     it('should sanitize html', () => {
       let model = createModel('text/html', '<h1>foo <script>window.x=1></scrip></h1>');
-      let f = new HTMLRendererFactory();
-      let trusted = false;
+      let f = htmlRendererFactory;
       let mimeType = 'text/html';
-      let w = f.createRenderer({ mimeType, sanitizer, trusted });
+      let w = f.createRenderer({ mimeType, ...defaultOptions });
       return w.renderModel(model).then(() => {
         expect(w.node.innerHTML).to.be('<h1>foo </h1>');
       });
@@ -434,23 +389,20 @@ describe('rendermime/factories', () => {
 
   });
 
-  describe('ImageRendererFactory', () => {
+  describe('imageRendererFactory', () => {
 
     describe('#mimeTypes', () => {
 
       it('should support multiple mimeTypes', () => {
-        let f = new ImageRendererFactory();
-        expect(f.mimeTypes).to.eql(['image/png', 'image/jpeg', 'image/gif']);
+        expect(imageRendererFactory.mimeTypes).to.eql(['image/png', 'image/jpeg', 'image/gif']);
       });
 
     });
 
-    describe('#canCreateRenderer()', () => {
+    describe('#safe', () => {
 
-      it('should be able to render trusted and untrusted image data', () => {
-        let f = new ImageRendererFactory();
-        expect(runCanCreateRenderer(f, true)).to.be(true);
-        expect(runCanCreateRenderer(f, false)).to.be(true);
+      it('should be safe', () => {
+        expect(imageRendererFactory.safe).to.be(true);
       });
 
     });
@@ -459,10 +411,10 @@ describe('rendermime/factories', () => {
 
       it('should create an <img> with the right mimeType', () => {
         let source = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-        let f = new ImageRendererFactory();
+        let f = imageRendererFactory;
         let mimeType = 'image/png';
         let model = createModel(mimeType, source);
-        let w = f.createRenderer({ mimeType, sanitizer, trusted: true });
+        let w = f.createRenderer({ mimeType, ...defaultOptions  });
         let el = w.node.firstChild as HTMLImageElement;
 
         return w.renderModel(model).then(() => {
@@ -473,8 +425,7 @@ describe('rendermime/factories', () => {
           source = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
           mimeType = 'image/gif';
           model = createModel(mimeType, source);
-          let trusted = true;
-          w = f.createRenderer({ mimeType, sanitizer, trusted });
+          w = f.createRenderer({ mimeType, ...defaultOptions });
           return w.renderModel(model);
         }).then(() => {
           el = w.node.firstChild as HTMLImageElement;

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -28,7 +28,7 @@ import {
 } from '@jupyterlab/notebook';
 
 import {
-  IRenderMime, RenderMime, TextRendererFactory, RenderedHTML
+  IRenderMime, RenderMime, RenderedHTML, defaultRendererFactories
 } from '@jupyterlab/rendermime';
 
 
@@ -163,20 +163,19 @@ namespace Private {
     }
   }
 
-
-  class JSONRendererFactory extends TextRendererFactory {
-
-    mimeTypes = ['application/json'];
-
+  const jsonRendererFactory = {
+    mimeTypes: ['application/json'],
+    safe: true,
     createRenderer(options: IRenderMime.IRendererOptions): IRenderMime.IRenderer {
       return new JSONRenderer(options);
     }
-  }
+  };
 
-  const initialFactories = RenderMime.getDefaultFactories();
   export
-  const rendermime = new RenderMime({ initialFactories });
-  rendermime.addFactory(new JSONRendererFactory(), 'application/json');
+  const rendermime = new RenderMime({
+    initialFactories: defaultRendererFactories
+  });
+  rendermime.addFactory(jsonRendererFactory, 10);
 }
 
 


### PR DESCRIPTION
All tests pass.

I had to change the name of the data attribute:

![image](https://user-images.githubusercontent.com/2096628/27864872-faeacbea-6155-11e7-9dbc-1036a6cb6a02.png)

The html renderer should also handle inline JavaScript, which is why the `createContextualFragment` is used.